### PR TITLE
Code coverage through XCBuild

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -43,6 +43,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Coverage
+      - name: Update Paths for SonarCloud
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          find: "/Users/runner/work/PCP-client-iOS-SDK/PCP-client-iOS-SDK/"
+          replace: ""
+          regex: false
+          include: "Coverage.xml"
       - name: Run SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         with:

--- a/PCPClientTestPlan.xctestplan
+++ b/PCPClientTestPlan.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "50143A09-AEC4-4C27-90D4-9AEC069728A7",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "PCPClientTests",
+        "name" : "PCPClientTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Sources/PCPClient/PCPClient.swift
+++ b/Sources/PCPClient/PCPClient.swift
@@ -5,3 +5,12 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 //
+
+public struct PCPClient {
+    public func frameworkName(isShortName: Bool) -> String {
+        if isShortName {
+            return "PCPC"
+        }
+        return "PCPClient"
+    }
+}

--- a/Tests/PCPClientTests/PCPClientTests.swift
+++ b/Tests/PCPClientTests/PCPClientTests.swift
@@ -3,10 +3,10 @@ import XCTest
 
 final class PCPClientTests: XCTestCase {
     func testExample() throws {
-        // XCTest Documentation
-        // https://developer.apple.com/documentation/xctest
+        let sut = PCPClient()
 
-        // Defining Test Cases and Test Methods
-        // https://developer.apple.com/documentation/xctest/defining_test_cases_and_test_methods
+        let result = sut.frameworkName(isShortName: true)
+
+        XCTAssertEqual(result, "PCPC")
     }
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,4 +7,4 @@ sonar.sources=./Sources/
 sonar.tests=./Tests/
 
 sonar.swift.excludedPathsFromCoverage=./Tests/
-
+sonar.coverage.exclusions=./Tests/**/*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,6 +4,7 @@ sonar.organization=payone-gmbh
 sonar.projectName=PCP-client-iOS-SDK
 
 sonar.sources=./Sources/
+sonar.tests=./Tests/
 
-sonar.swift.excludedPathsFromCoverage=./Tests.
+sonar.swift.excludedPathsFromCoverage=./Tests/
 


### PR DESCRIPTION
Adds code coverage in SonarCloud by adding coverage from XCBuild which is slower on CI but seems to work.